### PR TITLE
Implement filter for ghost buys with checkbox

### DIFF
--- a/config_settings_default.json
+++ b/config_settings_default.json
@@ -3,5 +3,8 @@
     "window_size": "1080x420", 
     "show_active_journals_tab": false,
     "minimize_to_tray": false
+  },
+  "Trade": {
+    "filter_ghost_buys": false
   }
 }

--- a/controller.py
+++ b/controller.py
@@ -56,6 +56,7 @@ class CarrierController:
         self.view.button_clear_timer.configure(command=self.button_click_clear_timer)
         self.view.button_post_departure.configure(command=self.button_click_post_departure)
         self.view.button_post_trade_trade.configure(command=self.button_click_post_trade_trade)
+        self.view.checkbox_filter_ghost_buys_var.trace_add('write', lambda *args: self.settings.set_config('Trade', 'filter_ghost_buys', value=self.view.checkbox_filter_ghost_buys_var.get()))
         self.view.button_open_journal.configure(command=self.button_click_open_journal)
         self.view.button_check_updates.configure(command=lambda: self.check_app_update(notify_is_latest=True))
         self.view.button_reload_settings.configure(command=self.button_click_reload_settings)
@@ -167,6 +168,7 @@ class CarrierController:
             self.model.read_journals() # re-read journals to apply ignore list and custom order
             self.view.set_font_size(self.settings.get('font_size', 'UI'), self.settings.get('font_size', 'table'))
             self.root.geometry(self.settings.get('UI', 'window_size'))
+            self.view.checkbox_filter_ghost_buys_var.set(self.settings.get('Trade', 'filter_ghost_buys'))
             self.view.checkbox_show_active_journals_var.set(self.settings.get('UI', 'show_active_journals_tab'))
             self.view.checkbox_minimize_to_tray_var.set(self.settings.get('UI', 'minimize_to_tray'))
             self.setup_tray_icon()
@@ -256,7 +258,7 @@ class CarrierController:
     def update_tables_slow(self, now):
         pending_decom = self.model.get_rows_pending_decom()
         self.view.update_table_finance(self.model.get_data_finance(), pending_decom)
-        self.view.update_table_trade(*self.model.get_data_trade())
+        self.view.update_table_trade(*self.model.get_data_trade(filter_ghost_buys=self.view.checkbox_filter_ghost_buys_var.get())) #TODO: reduce update rate for performance
         self.view.update_table_services(self.model.get_data_services(), pending_decom) #TODO: reduce update rate for performance
         self.view.update_table_misc(self.model.get_data_misc(), pending_decom) #TODO: reduce update rate for performance
 

--- a/view.py
+++ b/view.py
@@ -129,6 +129,10 @@ class CarrierView:
         # self.button_post_trade.grid(row=0, column=0, sticky='sw')
         self.button_post_trade_trade.pack(side='left')
 
+        self.checkbox_filter_ghost_buys_var = tk.BooleanVar()
+        self.checkbox_filter_ghost_buys = ttk.Checkbutton(self.bottom_bar_trade, text='Filter Ghost Buys', variable=self.checkbox_filter_ghost_buys_var)
+        self.checkbox_filter_ghost_buys.pack(side='right')
+
         # finance tab
         self.sheet_finance = Sheet(self.tab_finance, name='sheet_finance')
 


### PR DESCRIPTION
Add a checkbox to filter ghost buys in the trade view, allowing users to toggle this setting. Update relevant data retrieval methods to respect this filter. Adjust the UI to include the new checkbox and ensure the application state reflects the user's choice.