### PR TITLE
Implement filter for ghost buys with checkbox

### DIFF
--- a/config_settings_default.json
+++ b/config_settings_default.json
@@ -6,5 +6,8 @@
     "window_size": "1080x420", 
     "show_active_journals_tab": false,
     "minimize_to_tray": false
+  },
+  "Trade": {
+    "filter_ghost_buys": false
   }
 }

--- a/controller.py
+++ b/controller.py
@@ -64,6 +64,7 @@ class CarrierController:
         self.view.button_clear_timer.configure(command=self.button_click_clear_timer)
         self.view.button_post_departure.configure(command=self.button_click_post_departure)
         self.view.button_post_trade_trade.configure(command=self.button_click_post_trade_trade)
+        self.view.checkbox_filter_ghost_buys_var.trace_add('write', lambda *args: self.settings.set_config('Trade', 'filter_ghost_buys', value=self.view.checkbox_filter_ghost_buys_var.get()))
         self.view.button_open_journal.configure(command=self.button_click_open_journal)
         self.view.button_check_updates.configure(command=lambda: self.check_app_update(notify_is_latest=True))
         self.view.button_reload_settings.configure(command=self.button_click_reload_settings)
@@ -199,6 +200,7 @@ class CarrierController:
             self.model.read_journals() # re-read journals to apply ignore list and custom order
             self.view.set_font_size(self.settings.get('font_size', 'UI'), self.settings.get('font_size', 'table'))
             self.root.geometry(self.settings.get('UI', 'window_size'))
+            self.view.checkbox_filter_ghost_buys_var.set(self.settings.get('Trade', 'filter_ghost_buys'))
             self.view.checkbox_show_active_journals_var.set(self.settings.get('UI', 'show_active_journals_tab'))
             self.view.checkbox_minimize_to_tray_var.set(self.settings.get('UI', 'minimize_to_tray'))
             self.setup_tray_icon()
@@ -290,7 +292,7 @@ class CarrierController:
     def update_tables_slow(self, now):
         pending_decom = self.model.get_rows_pending_decom()
         self.view.update_table_finance(self.model.get_data_finance(), pending_decom)
-        self.view.update_table_trade(*self.model.get_data_trade())
+        self.view.update_table_trade(*self.model.get_data_trade(filter_ghost_buys=self.view.checkbox_filter_ghost_buys_var.get())) #TODO: reduce update rate for performance
         self.view.update_table_services(self.model.get_data_services(), pending_decom) #TODO: reduce update rate for performance
         self.view.update_table_misc(self.model.get_data_misc(), pending_decom) #TODO: reduce update rate for performance
 

--- a/model.py
+++ b/model.py
@@ -909,19 +909,18 @@ class CarrierModel:
         return getHammerCountdown(latest_cooldown.to_datetime64()) if latest_cooldown is not None else None
 
     def get_formatted_largest_order(self, carrierID: int) -> tuple[str, str, int | float, int]|None:
-        df_active_trades = self.generate_info_trade(carrierID=carrierID)
+        df_active_trades = self.get_active_trades(carrierID=carrierID)
+        df_active_trades['Trade Type'] = df_active_trades.apply(lambda x: 'Loading' if x['PurchaseOrder'] > 0 else 'Unloading', axis=1)
+        df_active_trades['Amount'] = df_active_trades.apply(lambda x: x['PurchaseOrder'] if x['PurchaseOrder'] > 0 else x['SaleOrder'], axis=1).astype(float)
+        df_active_trades['Commodity'] = df_active_trades['Commodity'].apply(lambda x: self.df_commodities_all.loc[x]['name'] if x in self.df_commodities_all.index else None)
+        df_active_trades = df_active_trades[df_active_trades['Commodity'].notna()]
+        df_active_trades['timestamp'] = df_active_trades['timestamp'].apply(lambda x: datetime.strptime(x, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc))
+        df_active_trades = df_active_trades.sort_values('timestamp', ascending=False)
         if len(df_active_trades) == 0:
             return None
         else:
-            df_active_trades['Amount'] = df_active_trades['Amount'].str.replace(',', '').astype(float)
-            df_active_trades['Time Set (Local)'] = df_active_trades['Time Set (Local)'].apply(lambda x: datetime.strptime(x, '%x %X').replace(tzinfo=timezone.utc).astimezone())
-            df_active_trades.sort_values('Time Set (Local)', ascending=False, inplace=True)
-            total_tonnage = 0
-            for i in range(len(df_active_trades)):
-                total_tonnage += df_active_trades.iloc[i]['Amount']
-                if total_tonnage >= 25000:
-                    df_active_trades = df_active_trades.iloc[:i]
-                    break
+            df_active_trades = self.filter_likely_active_trades(df_active_trades, is_squadron_carrier=self.is_squadron_carrier(carrierID))
+            df_active_trades.sort_values('timestamp', ascending=False, inplace=True)
             df_active_trades.sort_values('Amount', ascending=False, inplace=True)
             largest_order = df_active_trades.iloc[0]
             commodity = largest_order['Commodity']
@@ -929,19 +928,29 @@ class CarrierModel:
             amount = round(amount / 500) * 500 / 1000
             if amount % 1 == 0:
                 amount = int(amount)
-            price = int(largest_order['Price'].replace(',', ''))
+            price = int(largest_order['Price'])
             order_type = largest_order['Trade Type'].lower()
             return (order_type, commodity, amount, price)
 
-    def get_data_trade(self) -> tuple[pd.DataFrame, list[int]|None]:
-        trades = [self.generate_info_trade(carrierID) for carrierID in self.sorted_ids_display()]
+    def filter_likely_active_trades(self, df_active_trades: pd.DataFrame, is_squadron_carrier: bool=False) -> pd.DataFrame:
+        result = df_active_trades.copy()
+        total_tonnage = 0
+        for i in range(len(result)):
+            total_tonnage += result.iloc[i]['Amount']
+            if total_tonnage >= (60000 if is_squadron_carrier else 25000):
+                result = result.iloc[:i]
+                break
+        return result
+
+    def get_data_trade(self, filter_ghost_buys: bool=False) -> tuple[pd.DataFrame, list[int]|None]:
+        trades = [self.generate_info_trade(carrierID, filter_ghost_buys=filter_ghost_buys) for carrierID in self.sorted_ids_display()]
         df = pd.concat(trades, axis=0, ignore_index=True) if len(trades) > 0 else pd.DataFrame(columns=['CarrierID', 'Carrier Name', 'Trade Type', 'Amount', 'Commodity', 'Price', 'Time Set (Local)', 'Pending Decom'])
         self.trade_carrierIDs: list[int] = df['CarrierID'].to_list()
         trades = df.drop(['Pending Decom', 'CarrierID'], axis=1, errors='ignore')
         pending_decom = [i for i, decomming in enumerate(df['Pending Decom']) if decomming == True]
         return trades.values.tolist(), pending_decom if len(pending_decom) > 0 else None
 
-    def generate_info_trade(self, carrierID: int) -> pd.DataFrame:
+    def generate_info_trade(self, carrierID: int, filter_ghost_buys: bool=False) -> pd.DataFrame:
         carrier_name = self.get_name(carrierID)
         active_trades = self.get_active_trades(carrierID)
         if len(active_trades) == 0:
@@ -952,9 +961,18 @@ class CarrierModel:
             active_trades['Commodity'] = active_trades['Commodity'].apply(lambda x: self.df_commodities_all.loc[x]['name'] if x in self.df_commodities_all.index else None)
             active_trades = active_trades[active_trades['Commodity'].notna()]
             active_trades['Trade Type'] = active_trades.apply(lambda x: 'Loading' if x['PurchaseOrder'] > 0 else 'Unloading', axis=1)
-            active_trades['Amount'] = active_trades.apply(lambda x: x['PurchaseOrder'] if x['PurchaseOrder'] > 0 else x['SaleOrder'], axis=1).apply(lambda x: f'{int(x):,}')
-            active_trades['Price'] = active_trades['Price'].apply(lambda x: f'{int(x):,}')
+            active_trades['Amount'] = active_trades.apply(lambda x: x['PurchaseOrder'] if x['PurchaseOrder'] > 0 else x['SaleOrder'], axis=1)
             active_trades['Time Set (Local)'] = active_trades['timestamp'].apply(lambda x: datetime.strptime(x, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc).astimezone().strftime('%x %X'))
+            if filter_ghost_buys:
+                unloading_trades = active_trades[active_trades['Trade Type'] == 'Unloading'].copy()
+                likely_active_trades = self.filter_likely_active_trades(active_trades)
+                if unloading_trades.empty:
+                    active_trades = likely_active_trades
+                else:
+                    active_trades = pd.concat([unloading_trades, likely_active_trades]).sort_values('Time Set (Local)', ascending=False).drop_duplicates().reset_index(drop=True)
+            active_trades = active_trades.sort_values('timestamp', ascending=False)
+            active_trades['Amount'] = active_trades['Amount'].apply(lambda x: f'{int(x):,}')
+            active_trades['Price'] = active_trades['Price'].apply(lambda x: f'{int(x):,}')
             active_trades['Pending Decom'] = self.get_pending_decom(carrierID=carrierID)
             return active_trades[['CarrierID', 'Carrier Name', 'Trade Type', 'Amount', 'Commodity', 'Price', 'Time Set (Local)', 'Pending Decom']]
 

--- a/view.py
+++ b/view.py
@@ -145,6 +145,10 @@ class CarrierView:
         # self.button_post_trade.grid(row=0, column=0, sticky='sw')
         self.button_post_trade_trade.pack(side='left')
 
+        self.checkbox_filter_ghost_buys_var = tk.BooleanVar()
+        self.checkbox_filter_ghost_buys = ttk.Checkbutton(self.bottom_bar_trade, text='Filter Ghost Buys', variable=self.checkbox_filter_ghost_buys_var)
+        self.checkbox_filter_ghost_buys.pack(side='right')
+
         # finance tab
         self.sheet_finance = Sheet(self.tab_finance, name='sheet_finance')
 


### PR DESCRIPTION
Add a checkbox to filter out ghost buys in trade data, allowing users to customize their view of active trades. Update relevant methods to respect this setting.