### PR TITLE
Implement thread support for Discord webhooks

### DIFF
--- a/discord_handler.py
+++ b/discord_handler.py
@@ -9,6 +9,7 @@ class DiscordWebhookHandler:
     
     def __init__(self, webhook_urls: str, userID: str = ''):
         self.webhook_urls = [url for url in webhook_urls.replace(' ', '').split(',') if url]
+        self.webhook_thread_ids = [url.split('?thread_id=')[1] if '?thread_id=' in url else None for url in self.webhook_urls] 
         self.webhooks = [discord.SyncWebhook.from_url(url) for url in self.webhook_urls]
         print(f"Initialized DiscordWebhookHandler with {len(self.webhooks)} webhooks.")
         self.userID = userID
@@ -18,16 +19,25 @@ class DiscordWebhookHandler:
     def send_message(self, message: str, ping: bool = False):
         if ping:
             message = self._get_ping_message() + " " + message
-        for webhook in self.webhooks:
-            webhook.send(message, username=self.username, avatar_url=self.avatar_url)
+        for webhook, thread_id in zip(self.webhooks, self.webhook_thread_ids):
+            if thread_id:
+                webhook.send(message, username=self.username, avatar_url=self.avatar_url, thread=discord.Object(id=thread_id))
+            else:
+                webhook.send(message, username=self.username, avatar_url=self.avatar_url)
 
     def _send_embed(self, embed: discord.Embed, ping: bool = False):
         if ping:
-            for webhook in self.webhooks:
-                webhook.send(self._get_ping_message(), embed=embed, username=self.username, avatar_url=self.avatar_url)
+            for webhook, thread_id in zip(self.webhooks, self.webhook_thread_ids):
+                if thread_id:
+                    webhook.send(self._get_ping_message(), embed=embed, username=self.username, avatar_url=self.avatar_url, thread=discord.Object(id=thread_id))
+                else:
+                    webhook.send(self._get_ping_message(), embed=embed, username=self.username, avatar_url=self.avatar_url)
         else:
-            for webhook in self.webhooks:
-                webhook.send(embed=embed, username=self.username, avatar_url=self.avatar_url)
+            for webhook, thread_id in zip(self.webhooks, self.webhook_thread_ids):
+                if thread_id:
+                    webhook.send(embed=embed, username=self.username, avatar_url=self.avatar_url, thread=discord.Object(id=thread_id))
+                else:
+                    webhook.send(embed=embed, username=self.username, avatar_url=self.avatar_url)
 
     def send_message_with_embed(self, title: str, description: str, image_url: str|None=None, ping: bool = False):
         embed = discord.Embed(


### PR DESCRIPTION
Enhance the Discord webhook handler to support sending messages and embeds to specific threads by extracting thread IDs from the provided webhook URLs.