### PR TITLE
Fixed linking to prerelease even when update is not prerelease

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -33,7 +33,7 @@ from settings import Settings, SettingsValidationError
 from model import CarrierModel
 from view import CarrierView, TradePostView, ManualTimerView
 from station_parser import EDSMError, getStations
-from utility import getHammerCountdown, checkTimerFormat, getTimerStatDescription, getCurrentVersion, getLatestVersion, getLatestPrereleaseVersion, getResourcePath, isOnPrerelease, isUpdateAvailable, getSettingsPath, getSettingsDefaultPath, getSettingsDir, getAppDir, getCachePath, open_file, getInfoHash, getExpectedJumpTimer
+from utility import getHammerCountdown, checkTimerFormat, getTimerStatDescription, getCurrentVersion, getLatestVersion, getPrereleaseUpdateVersion, getResourcePath, isOnPrerelease, isUpdateAvailable, getSettingsPath, getSettingsDefaultPath, getSettingsDir, getAppDir, getCachePath, open_file, getInfoHash, getExpectedJumpTimer
 from decos import debounce
 from discord_handler import DiscordWebhookHandler
 from config import PLOT_WARN, UPDATE_INTERVAL, UPDATE_INTERVAL_TIMER_STATS, REDRAW_INTERVAL_FAST, REDRAW_INTERVAL_SLOW, REMIND_INTERVAL, PLOT_REMIND, SAVE_CACHE_INTERVAL, ladder_systems, SUPABASE_URL, SUPABASE_KEY
@@ -143,7 +143,7 @@ class CarrierController:
     def check_app_update(self, notify_is_latest:bool=False):
         if isUpdateAvailable():
             if isOnPrerelease():
-                version_latest = getLatestPrereleaseVersion()
+                version_latest = getPrereleaseUpdateVersion()
             else:
                 version_latest = getLatestVersion()
             prompt = f'New version available: {version_latest}\nGo to download?'

--- a/utility.py
+++ b/utility.py
@@ -121,6 +121,9 @@ def getLatestPrereleaseVersion() -> str|None:
     # return the highest semver prerelease of the same major.minor
     return max(pre_versions, key=lambda t: version.parse(t))
 
+def getPrereleaseUpdateVersion() -> str|None:
+    return max([getLatestPrereleaseVersion(), getLatestVersion()], key=lambda t: version.parse(t))
+
 def getCurrentVersion() -> str:
     with open(getResourcePath('VERSION'), 'r') as f:
         return f.readline().strip()


### PR DESCRIPTION
Replace the `getLatestPrereleaseVersion` function with `getPrereleaseUpdateVersion` to streamline the process of obtaining the latest prerelease version. This change enhances the clarity and efficiency of version checking.