### PR TITLE
Default station selection to Chadwick Dock when in Gali

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -500,7 +500,12 @@ class CarrierController:
                     market_ids = [market_ids[i] for i in L + M]
                     market_updated = [market_updated[i] for i in L + M]
                     if len(stations) > 0:
-                        trade_post_view = TradePostView(self.view.root, carrier_name=carrier_name, trade_type=trade_type, commodity=commodity, stations=stations, pad_sizes=pad_sizes, system=system, amount=amount, market_ids=market_ids, market_updated=market_updated, price=price)
+                        if system == 'Gali':
+                            chadwick_index = next((i for i, station in enumerate(stations) if station == 'Chadwick Dock'), None)
+                            if chadwick_index is not None:
+                                trade_post_view = TradePostView(self.view.root, carrier_name=carrier_name, trade_type=trade_type, commodity=commodity, stations=stations, pad_sizes=pad_sizes, system=system, amount=amount, market_ids=market_ids, market_updated=market_updated, price=price, default_station_index=chadwick_index)
+                        else:
+                            trade_post_view = TradePostView(self.view.root, carrier_name=carrier_name, trade_type=trade_type, commodity=commodity, stations=stations, pad_sizes=pad_sizes, system=system, amount=amount, market_ids=market_ids, market_updated=market_updated, price=price)
                         trade_post_view.button_post.configure(command=lambda: self.button_click_post(trade_post_view=trade_post_view, carrier_name=carrier_name, carrier_callsign=carrier_callsign, trade_type=trade_type, commodity=commodity, system=system, amount=amount))
                     else:
                         self.view.show_message_box_warning('No station', f'There are no stations in this system ({system})')

--- a/view.py
+++ b/view.py
@@ -369,7 +369,7 @@ class CarrierView:
 
 class TradePostView:
     def __init__(self, root, carrier_name:str, trade_type:Literal['loading', 'unloading'], commodity:str, stations:list[str], pad_sizes:list[Literal['L', 'M']], system:str, amount:int|float, 
-                 market_ids:list[str], market_updated:list[str], price:str|int):
+                 market_ids:list[str], market_updated:list[str], price:str|int, default_station_index:int=0):
         self.trade_type = trade_type
         self.commodity = commodity
         self.pad_sizes = pad_sizes
@@ -394,7 +394,7 @@ class TradePostView:
         self.label_from_to = ttk.Label(self.popup, text='from' if trade_type=='loading' else 'to')
         self.label_from_to.grid(row=0, column=4, padx=2)
         self.cbox_stations = ttk.Combobox(self.popup, values=stations)
-        self.cbox_stations.current(0)
+        self.cbox_stations.current(default_station_index)
         self.cbox_stations.bind('<<ComboboxSelected>>', self.station_selected)
         self.cbox_stations.grid(row=0, column=5, padx=2)
         self.cbox_pad_size = ttk.Combobox(self.popup, values=['L', 'M'], state='readonly', width=2)


### PR DESCRIPTION
Add functionality to set the default station index to Chadwick Dock when the Gali system is selected, enhancing user experience in the TradePostView.