### PR TITLE
Fixed Windows installer folder name

### DIFF
--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -16,6 +16,7 @@ WizardStyle=modern
 WizardImageFile="{#InputDir}\..\..\installer\Inno_wizard_image.png"
 SetupIconFile="{#InputDir}\_internal\images\EDCM.ico"
 DefaultDirName={autopf}\EDCM
+DefaultGroupName=Skywalker-Elite
 OutputDir={#OutputDirA}
 OutputBaseFilename=EDCM-Setup-{#AppVersion}
 Compression=lzma


### PR DESCRIPTION
Include a default group name "Skywalker-Elite" in the installer configuration.