### PR TITLE
Allow displaying some additional columns on Jumps tab

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -254,6 +254,11 @@ class CarrierController:
                         self.webhook_handler_carrier[callsign + '_public'] = DiscordWebhookHandler(carrier_notification_settings.get('webhook_public'), carrier_notification_settings.get('userID'))
             self.apply_settings_to_model()
             self.view.set_font_size(self.settings.get('font_size', 'UI'), self.settings.get('font_size', 'table'))
+            custom_jumps_headers = []
+            if self.settings.get('advanced', 'show_cmdr_name_on_jumps_tab'): custom_jumps_headers.append('CMDR Name')
+            if self.settings.get('advanced', 'show_squad_name_on_jumps_tab'): custom_jumps_headers.append('Squadron')
+            if self.settings.get('advanced', 'show_free_space_on_jumps_tab'): custom_jumps_headers.append('Free Space')
+            self.view.set_custom_jumps_headers(custom_jumps_headers)
             self.root.geometry(self.settings.get('UI', 'window_size'))
             self.view.checkbox_filter_ghost_buys_var.set(self.settings.get('Trade', 'filter_ghost_buys'))
             self.view.checkbox_show_active_journals_var.set(self.settings.get('UI', 'show_active_journals_tab'))
@@ -271,6 +276,11 @@ class CarrierController:
                 if override[callsign].get('notify_while_ignored', False):
                     self.model.add_notify_while_ignored_list(callsign)
         self.model.set_custom_order(self.settings.get('advanced', 'custom_order'))
+        self.model.set_custom_jumps_columns({
+            'cmdrname': self.settings.get('advanced', 'show_cmdr_name_on_jumps_tab'),
+            'squadname': self.settings.get('advanced', 'show_squad_name_on_jumps_tab'),
+            'freespace': self.settings.get('advanced', 'show_free_space_on_jumps_tab')
+        })
         self.model.set_squadron_abbv_mapping(self.settings.get('name_customization', 'squadron_abbv'))
         self.model.read_journals() # re-read journals to apply ignore list and custom order
     

--- a/model.py
+++ b/model.py
@@ -236,6 +236,7 @@ class CarrierModel:
         self._sfc_white_list = []
         self._notify_while_ignored_list = []
         self.custom_order = []
+        self.custom_jumps_columns = {}
         self._squadron_abbv_mapping = {}
         self._callback_status_change = lambda carrierID, status_old, status_new: print(f'{self.get_name(carrierID)} status changed from {status_old} to {status_new}')
         self.df_commodities = pd.read_csv(getResourcePath(path.join('3rdParty', 'aussig.BGS-Tally', 'commodity.csv')))
@@ -518,6 +519,9 @@ class CarrierModel:
     def set_custom_order(self, call_signs: list[str]):
         self.custom_order = call_signs
     
+    def set_custom_jumps_columns(self, custom_jumps_columns: dict):
+        self.custom_jumps_columns = custom_jumps_columns
+
     def add_sfc_whitelist(self, call_signs: list[str]):
         for call_sign in call_signs:
             carrierID = self.get_id_by_callsign(call_sign)
@@ -682,69 +686,60 @@ class CarrierModel:
 
     def generateInfo(self, carrierID: int, now: datetime):
         carrier = self.get_carriers()[carrierID]
+        carrier_cmdr = self.generate_info_cmdr_name(carrierID)
+        carrier_squad = self.generate_info_squadron_name(carrierID)
+        carrier_free_space = self.generate_info_space_usage(carrierID)[5]
         location_system, location_body = getLocation(carrier['current_system'], carrier['current_body'], carrier['current_body_id'])
         fuel_level = carrier['Fuel']['FuelLevel']
         timer = self.manual_timers.get(carrierID, None)
         timer = timer['time'].strftime('%H:%M:%S') if timer is not None else ''
+
+        # Destination system/body
         if carrier['status'] == 'jumping':
             destination_system, destination_body = getLocation(carrier['destination_system'], carrier['destination_body'], carrier['destination_body_id'])
+        else:
+            destination_system, destination_body = "", ""
+
+        # Timer
+        if carrier['status'] == 'jumping':
             time_diff = carrier['latest_depart'] - now
-            h, m, s = getHMS(time_diff.total_seconds())
-            return (
-                f"{carrier['Name']}", 
-                f"{carrier['Callsign']}", 
-                f"{fuel_level}",
-                f"{location_system}", 
-                f"{location_body}", 
-                f"Pad Locked" if time_diff < PADLOCK else "Jump Locked" if time_diff < JUMPLOCK else f"Jumping",
-                f"{destination_system}", 
-                f"{destination_body}", 
-                f"{h:.0f} h {m:02.0f} m {s:02.0f} s", 
-                f"{timer}"
-                )
         elif carrier['status'] == 'cool_down':
             time_diff = CD - (now - carrier['latest_depart'])
-            h, m, s = getHMS(time_diff.total_seconds())
-            return (
-                f"{carrier['Name']}", 
-                f"{carrier['Callsign']}", 
-                f"{fuel_level}",
-                f"{location_system}", 
-                f"{location_body}", 
-                f"Cooling Down",
-                f"", 
-                f"",
-                f"{h:.0f} h {m:02.0f} m {s:02.0f} s", 
-                f"{timer}"
-                )
         elif carrier['status'] == 'cool_down_cancel':
             time_diff = CD_cancel - (now - carrier['last_cancel']['timestamp'])
+
+        if carrier['status'] in ['jumping', 'cool_down', 'cool_down_cancel']:
             h, m, s = getHMS(time_diff.total_seconds())
-            return (
-                f"{carrier['Name']}", 
-                f"{carrier['Callsign']}", 
-                f"{fuel_level}",
-                f"{location_system}", 
-                f"{location_body}", 
-                f"Cooling Down",
-                f"", 
-                f"",
-                f"{h:.0f} h {m:02.0f} m {s:02.0f} s", 
-                f"{timer}"
-                )
+            timer_string = f"{h:.0f} h {m:02.0f} m {s:02.0f} s"
         else:
-            return (
-                f"{carrier['Name']}", 
-                f"{carrier['Callsign']}", 
-                f"{fuel_level}",
-                f"{location_system}", 
-                f"{location_body}", 
-                f"Idle",
-                f"", 
-                f"",
-                f"",
-                f"{timer}"
-                )
+            timer_string = f""
+
+        # Status
+        if carrier['status'] == 'jumping':
+            carrier_status = f"Pad Locked" if time_diff < PADLOCK else "Jump Locked" if time_diff < JUMPLOCK else f"Jumping"
+        elif carrier['status'] in ['cool_down', 'cool_down_cancel']:
+            carrier_status = f"Cooling Down"
+        else:
+            carrier_status = f"Idle"
+
+        returns = [
+            f"{carrier['Name']}", 
+            f"{carrier['Callsign']}", 
+            f"{fuel_level}",
+            f"{location_system}", 
+            f"{location_body}",
+            carrier_status,
+            f"{destination_system}", 
+            f"{destination_body}", 
+            timer_string,
+            f"{timer}",
+        ]
+
+        if self.custom_jumps_columns['cmdrname']: returns.append(f"{carrier_cmdr}")
+        if self.custom_jumps_columns['squadname']: returns.append(f"{carrier_squad}")
+        if self.custom_jumps_columns['freespace']: returns.append(f"{carrier_free_space}")
+
+        return tuple(returns)
     
     def get_data_finance(self):
         df = pd.DataFrame([self.generate_info_finance(carrierID) for carrierID in self.sorted_ids_display()], columns=['Carrier Name', 'Squadron', 'Carrier Balance', 'CMDR Balance', 'Services Upkeep', 'Est. Jump Cost', 'Funded Till'])

--- a/settings_default.toml
+++ b/settings_default.toml
@@ -112,6 +112,10 @@ squadron_abbv = [
 # These are advanced settings. You should not need to edit these unless you know what you are doing.
 ignore_list = [] # List of carriers to ignore. This is a list of carrier IDs (example: ["IGN-ORE", "SEC-RET", "A0C-35F"])
 custom_order = [] # Custom order of carriers. This is a list of carrier IDs (example: ["FC0-001", "FC0-002"]). Carriers in this list appear first; all others are sorted by time bought (if available).
+show_cmdr_name_on_jumps_tab = false # Show each carrier owner's CMDR name on Jumps tab
+show_squad_name_on_jumps_tab = false # Show each carrier owner's squadron name on Jumps tab
+show_free_space_on_jumps_tab = false # Show each carrier's free space on Jumps tab
+
 # You can override notification settings for specific carriers using the carrier_notification_overrides setting below.
 # Each entry in the list should be a dictionary where the key is the carrier ID and the value is another dictionary with the settings to override.
 # Valid settings to override are every setting under the [notifications] section (e.g., "jump_completed", "jump_completed_sound", etc.) and the [discord] section (e.g., "webhook", "userID").

--- a/view.py
+++ b/view.py
@@ -8,6 +8,11 @@ from idlelib.tooltip import Hovertip
 from config import WINDOW_SIZE_TIMER, font_sizes, TOOLTIP_HOVER_DELAY, TOOLTIP_BACKGROUND, TOOLTIP_FOREGROUND, WINDOW_SIZE
 from station_parser import getStockPrice
 
+default_jumps_headers = [
+    'Carrier Name', 'Carrier ID', 'Fuel', 'Current System', 'Body',
+    'Status', 'Destination System', 'Body', 'Timer', 'Plot Timer',
+]
+
 class MenuOption(NamedTuple):
         label: str
         func: Callable[..., None]
@@ -101,10 +106,8 @@ class CarrierView:
         self.sheet_jumps = Sheet(self.tab_jumps, name='sheet_jumps')
 
         # Set column headers
-        self.sheet_jumps.headers([
-            'Carrier Name', 'Carrier ID', 'Fuel', 'Current System', 'Body',
-            'Status', 'Destination System', 'Body', 'Timer', 'Plot Timer',
-        ])
+        self.sheet_jumps.headers(default_jumps_headers)
+        self.custom_jumps_headers = []
 
         self.configure_sheet(self.sheet_jumps)
         
@@ -348,6 +351,13 @@ class CarrierView:
         # 5) some pure-tk popups (Combobox listbox, Menu) still need an option_add
         self.root.option_add("*Listbox*Font", ("Calibri", size, "normal"))
         self.root.option_add("*Menu*Font",    ("Calibri", size, "normal"))
+
+    def reset_jumps_headers(self):
+        self.sheet_jumps.headers(default_jumps_headers + self.custom_jumps_headers)
+
+    def set_custom_jumps_headers(self, custom_jumps_headers: list[str]):
+        self.custom_jumps_headers = custom_jumps_headers
+        self.reset_jumps_headers()
 
     def setup_right_click_menu(self):
         if self.menu_options is None:


### PR DESCRIPTION
This adds three new settings to `[advanced]`:
```
show_cmdr_name_on_jumps_tab = false
show_squad_name_on_jumps_tab = false
show_free_space_on_jumps_tab = false
```

If set to true, additional columns are displayed on the Jumps tab:
<img width="1000" height="80" alt="image" src="https://github.com/user-attachments/assets/11977680-4fb7-41f9-8217-1d1f8d9f8ef2" />

I know there's a better way to read the settings, but not sure how to access `CarrierController.settings` from inside `CarrierModel` and `CarrierView`. Do I need to add something to `apply_settings_to_model()` and something similar for the view?