### PR TITLE
Fix ladder name not applying to commander location

### DIFF
--- a/model.py
+++ b/model.py
@@ -856,7 +856,7 @@ class CarrierModel:
                             system = get_custom_system_name(system)
                 else:
                     station = 'Undocked'
-            return (system if system is not None else 'Unknown', station)
+            return (get_custom_system_name(system) if system is not None else 'Unknown', station)
         return ('Unknown', 'Unknown')
     
     def generate_info_squadron_name(self, carrierID: int) -> str:


### PR DESCRIPTION
Update the logic to ensure the custom system name is applied correctly when generating the commander location.