### PR TITLE
Fixed Dodec ports not showing in post trade dialogs

### DIFF
--- a/station_parser.py
+++ b/station_parser.py
@@ -22,6 +22,18 @@ def getStations(sys_name:str, details:bool=False) -> tuple[list[str], list[str],
         raise EDSMError(f"Error fetching station data: {result.status_code}")
     else:
         result = result.json()
+    # dirty fix with spansh to catch dodecs being classified as planetary outposts by EDSM
+    try:
+        spansh_stations = getStationsSpansh(result['id64'])
+    except SpanshError as e:
+        print(f"Error fetching station data from Spansh: {e}")
+        spansh_stations = []
+    for station in result['stations']:
+        if station['type'] == 'Planetary Outpost':
+            for spansh_station in spansh_stations:
+                if station['marketId'] == spansh_station['market_id'] and spansh_station['type'] == 'Dodec Starport':
+                    print(f"Reclassifying station {station['name']} from Planetary Outpost to Dodec Starport based on Spansh data")
+                    station['type'] = 'Dodec Starport'
     stations = [station for station in result['stations'] if station['type'] not in ['Fleet Carrier', 'Odyssey Settlement', 'Planetary Outpost', 'Planetary Port', 'Mega ship']]
     stations = [station for station in stations if station['haveMarket']]
     station_names = [s['name'] for s in stations]
@@ -75,6 +87,27 @@ def getStockPrice(trade_type:Literal['loading', 'unloading'], market_id:str=None
         price = commodity_info['sellPrice']
     return stock, price
 
+class SpanshError(Exception):
+    """Custom exception for Spansh API errors."""
+    pass
+
+@rate_limited(max_calls=1, period=60)
+def getStationsSpansh(system_id:int) -> list[dict]:
+    """
+    Get station names and types from Spansh API.
+    """
+    url = f'https://spansh.co.uk/api/system/{system_id}'
+    try:
+        result = requests.get(url)
+    except requests.exceptions.RequestException as e:
+        raise SpanshError(f"Error fetching station data from Spansh: {e}")
+    if result.status_code != 200:
+        raise SpanshError(f"Error fetching station data from Spansh: {result.status_code}")
+    else:
+        result = result.json()
+    stations = result.get('record', {}).get('stations', [])
+    return stations
+
 if __name__ == '__main__':
     # print(getStations('sol'))
     # print(getStations('anlave', True))
@@ -85,3 +118,5 @@ if __name__ == '__main__':
     # print(getMarketCommodityInfo(system_name='Anlave', station_name='Suri Park', commodity_name='Agronomic Treatment'))
     # print(getStockPrice('loading', system_name='Anlave', station_name='Suri Park', commodity_name='Agronomic Treatment'))
     # print(getStockPrice('loading', market_id=128127736, commodity_name='Agronomic Treatment'))
+    # print(getStationsSpansh(2140781119851))
+    print(getStations('Ceti Sector DL-Y d62'))

--- a/station_parser.py
+++ b/station_parser.py
@@ -91,7 +91,7 @@ class SpanshError(Exception):
     """Custom exception for Spansh API errors."""
     pass
 
-@rate_limited(max_calls=1, period=60)
+@rate_limited(max_calls=1, period=600)
 def getStationsSpansh(system_id:int) -> list[dict]:
     """
     Get station names and types from Spansh API.


### PR DESCRIPTION
Implement a check to reclassify stations from Planetary Outpost to Dodec Starport based on data from the Spansh API. Decrease the rate limit for fetching data from Spansh to prevent excessive requests.