### PR TITLE
Fix copy ID functionality in services tab

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1292,7 +1292,7 @@ class CarrierController:
             self.view.show_message_box_warning('Warning', 'Please select one carrier and one carrier only!')
 
     def menu_click_copy_name_callsign_services(self):
-        selected_row = self.get_selected_row(sheet=self.view.sheet_services)
+        selected_row = self.get_selected_row(sheet=self.view.get_current_active_sheet())
         if selected_row is not None:
             carrierID = self.model.sorted_ids_display()[selected_row]
             carrier_name = self.model.get_name(carrierID)

--- a/view.py
+++ b/view.py
@@ -468,6 +468,11 @@ class CarrierView:
     
     def show_dropdown_popup(self, title: str, prompt: str, options: list[str]) -> int|None:
         return show_dropdown_popup(self.root, title, prompt, options)
+    
+    def get_current_active_sheet(self) -> Sheet|None:
+        current_tab_text = self.tab_controller.tab(self.tab_controller.select(), "text")
+        sheet = getattr(self, f'sheet_{current_tab_text.lower().replace(" ", "_")}', None)
+        return sheet
 
 class TradePostView:
     def __init__(self, root, carrier_name:str, trade_type:Literal['loading', 'unloading'], commodity:str, stations:list[str], pad_sizes:list[Literal['L', 'M']], system:str, amount:int|float, 


### PR DESCRIPTION
Resolve an issue where the copy ID functionality was not working correctly in the services tab by updating the method to retrieve the current active sheet. Additionally, a new method to get the current active sheet has been added.